### PR TITLE
Release Codex Deck v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.3 - 2026-07-19
+
+- Fix completed tasks remaining stuck in the green finished state after they are opened.
+- Track each structural `task_complete` revision instead of comparing rollout modification times, so harmless file touches cannot resurrect an acknowledged completion.
+- Detect the task currently open in each Codex renderer even when it is outside that host's six native Micro slots.
+- Propagate the content-free active-task and completion-revision signals through the authenticated multi-host relay, allowing a mirrored task opened on either computer to clear correctly.
+- Preserve the visible completion transition for a task that was already open while it ran; only a later activation or Stream Deck press acknowledges it.
+- Prevent delayed completion metadata from overriding a newer native working/thinking state.
+
 ## 0.6.2 - 2026-07-19
 
 - Added explicit per-host `READY`, `DEGRADED`, `CONNECT`, and `OFFLINE` state to the Windows/Mac target key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-stream-deck",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-stream-deck",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-stream-deck",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": false,
   "type": "module",
   "description": "Unofficial Codex Micro bridge for Stream Deck on Windows and macOS, with optional multi-host relay",

--- a/src/codex-micro-renderer-bridge.ts
+++ b/src/codex-micro-renderer-bridge.ts
@@ -214,8 +214,12 @@ const SNAPSHOT_EXPRESSION = `(async () => {
   const theme = explicitDark || (!explicitLight && (luminance != null ? luminance < 0.42 : matchMedia('(prefers-color-scheme: dark)').matches))
     ? 'dark'
     : 'light';
+  const activeThreadKey = document.querySelector('[data-app-action-sidebar-thread-id][aria-current="page"]')
+    ?.getAttribute('data-app-action-sidebar-thread-id')
+    ?? document.querySelector('[data-above-composer-conversation-id]')?.getAttribute('data-above-composer-conversation-id')
+    ?? undefined;
 
-  return { slots, layout, agentSource, lightingAutoOff, theme };
+  return { slots, activeThreadKey, layout, agentSource, lightingAutoOff, theme };
 })()`;
 
 export class CodexMicroRendererBridge {

--- a/src/relay-protocol.ts
+++ b/src/relay-protocol.ts
@@ -41,6 +41,8 @@ type SessionOwner = { input: HostSnapshot; session: HostSessionPresence };
 
 export class HostActivityIndex {
   private readonly activity = new Map<string, ActivityRecord>();
+  private readonly acknowledgedCompletions = new Map<string, number>();
+  private activeThreads = new Set<string>();
 
   merge(inputs: HostSnapshot[], now = Date.now(), authoritativeHostId?: string): RoutedAgentSlot[] {
     const routed: RoutedAgentSlot[] = [];
@@ -77,7 +79,17 @@ export class HostActivityIndex {
       mirrors.set(identity, candidates);
     }
     const sessionOwners = sessionOwnerIndex(inputs);
-    const merged = [...mirrors.entries()].map(([identity, candidates]) => mergeMirrors(candidates, sessionOwners.get(identity)));
+    const activeThreads = new Set([
+      ...inputs
+      .map((input) => input.snapshot.activeThreadKey)
+      .filter((threadKey): threadKey is string => threadKey != null)
+      .map(threadIdentity),
+      ...routed.filter((slot) => slot.selected && slot.threadKey).map((slot) => threadIdentity(slot.threadKey!))
+    ]);
+    const newlyActiveThreads = new Set([...activeThreads].filter((identity) => !this.activeThreads.has(identity)));
+    const merged = [...mirrors.entries()].map(([identity, candidates]) =>
+      mergeMirrors(identity, candidates, sessionOwners.get(identity), this.acknowledgedCompletions, newlyActiveThreads.has(identity)));
+    this.activeThreads = activeThreads;
     const byThread = new Map(merged.map((slot) => [threadIdentity(slot.threadKey!), slot]));
     const authority = inputs.find((input) => input.host.hostId === authoritativeHostId) ?? inputs[0]!;
 
@@ -195,10 +207,12 @@ export function parseRelayCommand(value: unknown): RelayCommand | null {
 function isSnapshot(value: unknown): value is MicroSnapshot {
   if (!isRecord(value) || !Array.isArray(value.slots) || value.slots.length !== 6 || !isRecord(value.layout)) return false;
   if (!value.slots.every((slot, index) => isRecord(slot) && slot.id === index && typeof slot.status === "string")) return false;
+  if (value.activeThreadKey != null && !isThreadKey(value.activeThreadKey)) return false;
   if (value.hostSessions == null) return true;
   return Array.isArray(value.hostSessions) && value.hostSessions.length <= 128 && value.hostSessions.every((session) =>
     isRecord(session) && isThreadKey(session.threadId) && validTimestamp(session.activityAt) != null &&
-    ["idle", "working", "complete"].includes(String(session.status))
+    ["idle", "working", "complete"].includes(String(session.status)) &&
+    (session.completionRevision == null || integerIn(session.completionRevision, 0, Number.MAX_SAFE_INTEGER))
   );
 }
 
@@ -227,7 +241,13 @@ function compareOwnership(left: RoutedAgentSlot, right: RoutedAgentSlot): number
   return compareActivity(left, right);
 }
 
-function mergeMirrors(candidates: RoutedAgentSlot[], sessionOwner?: SessionOwner): RoutedAgentSlot {
+function mergeMirrors(
+  identity: string,
+  candidates: RoutedAgentSlot[],
+  sessionOwner: SessionOwner | undefined,
+  acknowledgedCompletions: Map<string, number>,
+  newlyActiveOnAnyHost: boolean
+): RoutedAgentSlot {
   let owner = candidates[0]!;
   const explicitOwner = sessionOwner && candidates.find((candidate) => candidate.host.hostId === sessionOwner.input.host.hostId);
   if (explicitOwner) owner = explicitOwner;
@@ -243,9 +263,23 @@ function mergeMirrors(candidates: RoutedAgentSlot[], sessionOwner?: SessionOwner
   const ownedCandidates = candidates.filter((candidate) => candidate.ownedByHost === true);
   const recencyCandidates = ownedCandidates.length ? ownedCandidates : candidates;
   const sessionStatus = sessionOwner?.session.status;
-  const status = sessionStatus && sessionStatus !== "idle" && !["approval", "awaiting-approval", "awaiting-response", "unread", "error"].includes(strongest.status)
-    ? sessionStatus
-    : strongest.status;
+  const completionRevision = sessionOwner?.session.completionRevision;
+  const completionKey = sessionOwner ? `${sessionOwner.input.host.hostId}:${identity}` : identity;
+  if (sessionStatus === "complete" && completionRevision != null &&
+    newlyActiveOnAnyHost) {
+    acknowledgedCompletions.set(completionKey, completionRevision);
+  }
+  const completionAcknowledged = sessionStatus === "complete" && completionRevision != null &&
+    acknowledgedCompletions.get(completionKey) === completionRevision;
+  const liveOrAttention = ["working", "thinking", "approval", "awaiting-approval", "awaiting-response", "unread", "error"];
+  const completionLike = ["complete", "completed", "done"];
+  const status = completionAcknowledged && completionLike.includes(strongest.status)
+    ? "idle"
+    : sessionStatus === "complete" && !completionAcknowledged && !liveOrAttention.includes(strongest.status)
+      ? "complete"
+      : sessionStatus === "working" && !liveOrAttention.includes(strongest.status)
+        ? "working"
+        : strongest.status;
   const routedOwner = sessionOwner?.input.host ?? owner.host;
   return {
     ...owner,

--- a/src/session-ownership.ts
+++ b/src/session-ownership.ts
@@ -9,7 +9,8 @@ const THREAD_KEY = /(?:^|:)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9
 export class CodexSessionOwnershipIndex {
   private sessionIds = new Set<string>();
   private recentSessions: HostSessionPresence[] = [];
-  private openedAt = new Map<string, number>();
+  private acknowledgedCompletions = new Map<string, number>();
+  private activeSessions = new Set<string>();
   private refreshedAt = 0;
   private refreshInFlight?: Promise<void>;
 
@@ -20,13 +21,25 @@ export class CodexSessionOwnershipIndex {
 
   async annotate(snapshot: MicroSnapshot, now = Date.now()): Promise<MicroSnapshot> {
     await this.refreshIfNeeded(now);
+    const selectedSessions = new Set(snapshot.slots
+      .filter((slot) => slot.selected)
+      .map((slot) => sessionIdFromThreadKey(slot.threadKey))
+      .filter((sessionId): sessionId is string => sessionId != null));
+    const activeSessionId = sessionIdFromThreadKey(snapshot.activeThreadKey ?? null);
+    if (activeSessionId) selectedSessions.add(activeSessionId);
+    for (const session of this.recentSessions) {
+      if (session.status === "complete" && session.completionRevision != null && selectedSessions.has(session.threadId) &&
+        !this.activeSessions.has(session.threadId)) {
+        this.acknowledgedCompletions.set(session.threadId, session.completionRevision);
+      }
+    }
+    this.activeSessions = selectedSessions;
     return {
       ...snapshot,
       hostSessions: this.recentSessions.map((session) => ({
         ...session,
-        status: session.status === "complete" && (this.openedAt.get(session.threadId) ?? 0) >= session.activityAt
-          ? "idle"
-          : session.status
+        status: session.status === "complete" && session.completionRevision != null &&
+          this.acknowledgedCompletions.get(session.threadId) === session.completionRevision ? "idle" : session.status
       })),
       slots: snapshot.slots.map((slot) => {
         const sessionId = sessionIdFromThreadKey(slot.threadKey);
@@ -35,9 +48,13 @@ export class CodexSessionOwnershipIndex {
     };
   }
 
-  markOpened(threadKey: string, now = Date.now()): void {
+  markOpened(threadKey: string, _now = Date.now()): void {
     const sessionId = sessionIdFromThreadKey(threadKey);
-    if (sessionId) this.openedAt.set(sessionId, now);
+    if (!sessionId) return;
+    const session = this.recentSessions.find((candidate) => candidate.threadId === sessionId);
+    if (session?.status === "complete" && session.completionRevision != null) {
+      this.acknowledgedCompletions.set(sessionId, session.completionRevision);
+    }
   }
 
   private async refreshIfNeeded(now: number): Promise<void> {
@@ -88,13 +105,15 @@ export class CodexSessionOwnershipIndex {
       if (!uniqueRecent.has(file.threadId)) uniqueRecent.set(file.threadId, file);
     }
     const recent = [...uniqueRecent.values()].slice(0, 128);
-    this.recentSessions = await Promise.all(recent.map(async ({ threadId, path, activityAt }) => ({
-      threadId,
-      activityAt,
-      status: now - activityAt <= 15 * 60_000 ? await readRecentSessionStatus(path) : "idle"
-    })));
-    for (const [threadId, openedAt] of this.openedAt) {
-      if (now - openedAt > 86_400_000) this.openedAt.delete(threadId);
+    this.recentSessions = await Promise.all(recent.map(async ({ threadId, path, activityAt }) => {
+      const recentStatus = now - activityAt <= 15 * 60_000
+        ? await readRecentSessionStatus(path)
+        : { status: "idle" as const };
+      return { threadId, activityAt, ...recentStatus };
+    }));
+    const currentIds = new Set(this.recentSessions.map((session) => session.threadId));
+    for (const threadId of this.acknowledgedCompletions.keys()) {
+      if (!currentIds.has(threadId)) this.acknowledgedCompletions.delete(threadId);
     }
     this.refreshedAt = now;
   }
@@ -113,7 +132,7 @@ function defaultSessionRoots(): string[] {
   return [join(codexHome, "sessions"), join(codexHome, "archived_sessions")];
 }
 
-async function readRecentSessionStatus(path: string): Promise<HostSessionPresence["status"]> {
+async function readRecentSessionStatus(path: string): Promise<Pick<HostSessionPresence, "status" | "completionRevision">> {
   try {
     const handle = await open(path, "r");
     try {
@@ -128,13 +147,13 @@ async function readRecentSessionStatus(path: string): Promise<HostSessionPresenc
         tail.lastIndexOf('"type":"function_call"'),
         tail.lastIndexOf('"type":"turn_context"')
       );
-      if (activeAt > completedAt) return "working";
-      if (completedAt >= 0) return "complete";
-      return "idle";
+      if (activeAt > completedAt) return { status: "working" };
+      if (completedAt >= 0) return { status: "complete", completionRevision: info.size - length + completedAt };
+      return { status: "idle" };
     } finally {
       await handle.close();
     }
   } catch {
-    return "idle";
+    return { status: "idle" };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,14 @@ export type HostSessionPresence = {
   threadId: string;
   activityAt: number;
   status: "idle" | "working" | "complete";
+  /** Byte offset of the latest structural task_complete event; no task content is exposed. */
+  completionRevision?: number;
 };
 
 export type MicroSnapshot = {
   slots: MicroAgentSlot[];
+  /** Task currently open in the Codex renderer, even when it is outside the six native Micro slots. */
+  activeThreadKey?: string;
   layout: MicroLayout;
   agentSource: "pinned" | "recent" | "priority" | "custom";
   lightingAutoOff: string;

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "Name": "Codex Deck",
-  "Version": "0.6.2.0",
+  "Version": "0.6.3.0",
   "Author": "Dazer",
   "Description": "Unofficial Codex Micro bridge for Stream Deck on Windows and macOS, with optional multi-host relay.",
   "UUID": "com.simeo.codex-deck",

--- a/test/micro-bridge.test.ts
+++ b/test/micro-bridge.test.ts
@@ -34,6 +34,8 @@ test("renderer bridge uses native Micro events and discovers hashed modules at r
   assert.match(source, /createSubscriberAtom/);
   assert.match(source, /slots\.length === 6/);
   assert.match(source, /codex-micro-agent-source/);
+  assert.match(source, /data-app-action-sidebar-thread-id/);
+  assert.match(source, /activeThreadKey/);
   assert.match(source, /directSettingReader/);
   assert.match(source, /get-setting/);
   assert.match(source, /found\.node\.store\.get\.bind\(found\.node\.store\)/);

--- a/test/relay.test.ts
+++ b/test/relay.test.ts
@@ -52,8 +52,16 @@ test("relay command parser permits only the narrow native command surface", () =
 test("relay snapshot parser bounds and validates host session catalogs", async () => {
   const { parseRelayServerMessage } = await import("../src/relay-protocol.js");
   const valid = { type: "snapshot", protocol: 1, host, observedAt: 1, snapshot: structuredClone(snapshot) };
-  valid.snapshot.hostSessions = [{ threadId: "00000000-0000-4000-8000-000000000000", activityAt: 1, status: "working" }];
+  valid.snapshot.hostSessions = [{ threadId: "00000000-0000-4000-8000-000000000000", activityAt: 1, status: "working", completionRevision: 42 }];
   assert.notEqual(parseRelayServerMessage(valid), null);
+  valid.snapshot.activeThreadKey = "local:00000000-0000-4000-8000-000000000000";
+  assert.notEqual(parseRelayServerMessage(valid), null);
+  valid.snapshot.activeThreadKey = "local:not-a-thread";
+  assert.equal(parseRelayServerMessage(valid), null);
+  delete valid.snapshot.activeThreadKey;
+  const invalidRevision = structuredClone(valid);
+  invalidRevision.snapshot.hostSessions![0]!.completionRevision = -1;
+  assert.equal(parseRelayServerMessage(invalidRevision), null);
   const invalid = structuredClone(valid) as typeof valid & { snapshot: { hostSessions: unknown[] } };
   invalid.snapshot.hostSessions = Array.from({ length: 129 }, () => valid.snapshot.hostSessions![0]!);
   assert.equal(parseRelayServerMessage(invalid), null);
@@ -374,6 +382,42 @@ test("combined priority mode keeps freshly completed owner sessions ahead of idl
   assert.equal(merged[0]!.threadKey, completed);
   assert.equal(merged[0]!.host.platform, "darwin");
   assert.equal(merged[0]!.status, "complete");
+});
+
+test("a completion opened through a cross-host mirror stays idle until a new completion revision", () => {
+  const windows: CodexHost = { hostId: "11111111-1111-4111-8111-111111111111", hostName: "Windows", platform: "win32" };
+  const windowsSnapshot = structuredClone(snapshot);
+  const macSnapshot = structuredClone(snapshot);
+  const completed = "50000000-0000-4000-8000-000000000001";
+  for (const slot of [...windowsSnapshot.slots, ...macSnapshot.slots]) {
+    slot.status = "idle";
+    slot.selected = false;
+    slot.activityAt = 1;
+  }
+  windowsSnapshot.slots[0] = { ...windowsSnapshot.slots[0]!, threadKey: "50000000-0000-4000-8000-000000000099" };
+  windowsSnapshot.activeThreadKey = `local:${completed}`;
+  macSnapshot.slots[0] = { ...macSnapshot.slots[0]!, threadKey: completed, ownedByHost: true };
+  macSnapshot.hostSessions = [{ threadId: completed, activityAt: 1_900, status: "working" }];
+  const index = new HostActivityIndex();
+  const inputs = () => [
+    { host: windows, snapshot: windowsSnapshot, observedAt: 2_000 },
+    { host, snapshot: macSnapshot, observedAt: 2_000 }
+  ];
+
+  assert.equal(index.merge(inputs(), 2_000, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "working");
+  macSnapshot.hostSessions[0] = { threadId: completed, activityAt: 2_000, status: "complete", completionRevision: 10 };
+  assert.equal(index.merge(inputs(), 2_001, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "complete");
+  delete windowsSnapshot.activeThreadKey;
+  index.merge(inputs(), 2_002, windows.hostId);
+  windowsSnapshot.activeThreadKey = `local:${completed}`;
+  assert.equal(index.merge(inputs(), 2_003, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "idle");
+  delete windowsSnapshot.activeThreadKey;
+  assert.equal(index.merge(inputs(), 2_004, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "idle");
+
+  macSnapshot.hostSessions[0]!.completionRevision = 20;
+  assert.equal(index.merge(inputs(), 2_005, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "complete");
+  macSnapshot.slots[0]!.status = "working";
+  assert.equal(index.merge(inputs(), 2_006, windows.hostId).find((slot) => slot.threadKey === completed)?.status, "working");
 });
 
 test("authenticated relay publishes snapshots and dispatches typed commands", async () => {

--- a/test/session-ownership.test.ts
+++ b/test/session-ownership.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -52,6 +52,51 @@ test("recent local rollout tails expose structural working and completion state 
   }
 });
 
+test("acknowledging a completion survives later file touches but a new completion becomes unread", async () => {
+  const root = await mkdtemp(join(tmpdir(), "codex-deck-completion-ack-"));
+  try {
+    const threadId = "10000000-0000-4000-8000-000000000003";
+    const path = join(root, `rollout-now-${threadId}.jsonl`);
+    await writeFile(path, '{"type":"event_msg","payload":{"type":"task_complete"}}\n');
+    const index = new CodexSessionOwnershipIndex([root], 0);
+    const first = await index.annotate(snapshotFor(threadId, false), Date.now());
+    assert.equal(first.hostSessions?.find((session) => session.threadId === threadId)?.status, "complete");
+
+    const selected = await index.annotate(snapshotFor(threadId, true), Date.now() + 1);
+    assert.equal(selected.hostSessions?.find((session) => session.threadId === threadId)?.status, "idle");
+    await appendFile(path, '{"type":"event_msg","payload":{"type":"thread_opened"}}\n');
+    const afterTouch = await index.annotate(snapshotFor(threadId, false), Date.now() + 2);
+    assert.equal(afterTouch.hostSessions?.find((session) => session.threadId === threadId)?.status, "idle");
+
+    await appendFile(path, '{"type":"event_msg","payload":{"type":"agent_reasoning"}}\n{"type":"event_msg","payload":{"type":"task_complete"}}\n');
+    const nextCompletion = await index.annotate(snapshotFor(threadId, false), Date.now() + 3);
+    assert.equal(nextCompletion.hostSessions?.find((session) => session.threadId === threadId)?.status, "complete");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the active renderer task acknowledges completion outside the six Micro slots", async () => {
+  const root = await mkdtemp(join(tmpdir(), "codex-deck-active-thread-"));
+  try {
+    const threadId = "10000000-0000-4000-8000-000000000004";
+    const path = join(root, `rollout-now-${threadId}.jsonl`);
+    await writeFile(path, '{"type":"event_msg","payload":{"type":"agent_reasoning"}}\n');
+    const index = new CodexSessionOwnershipIndex([root], 0);
+    const value = snapshot();
+    value.activeThreadKey = `local:${threadId}`;
+    assert.equal((await index.annotate(value, Date.now())).hostSessions?.find((session) => session.threadId === threadId)?.status, "working");
+    await appendFile(path, '{"type":"event_msg","payload":{"type":"task_complete"}}\n');
+    assert.equal((await index.annotate(value, Date.now() + 1)).hostSessions?.find((session) => session.threadId === threadId)?.status, "complete");
+    delete value.activeThreadKey;
+    await index.annotate(value, Date.now() + 2);
+    value.activeThreadKey = `local:${threadId}`;
+    assert.equal((await index.annotate(value, Date.now() + 3)).hostSessions?.find((session) => session.threadId === threadId)?.status, "idle");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 function snapshot(): MicroSnapshot {
   return {
     slots: Array.from({ length: 6 }, (_, id) => ({
@@ -73,4 +118,10 @@ function snapshot(): MicroSnapshot {
     lightingAutoOff: "3-minutes",
     theme: "dark"
   };
+}
+
+function snapshotFor(threadId: string, selected: boolean): MicroSnapshot {
+  const value = snapshot();
+  value.slots[0] = { ...value.slots[0]!, threadKey: `local:${threadId}`, selected };
+  return value;
 }


### PR DESCRIPTION
## What changed

- tracks stable structural completion revisions instead of rollout modification times
- detects the task currently open in each renderer outside the six native Micro slots
- acknowledges mirrored completions from either computer through content-free relay fields
- preserves the visible finished transition until a later activation or Deck press
- prevents delayed completion metadata from overriding newer working/thinking state
- bumps the plugin and package to v0.6.3

## Why

Completed tasks could first appear idle, update to finished much later, and remain stuck until their Stream Deck key was pressed. The owning rollout and the renderer where the mirrored task was open could disagree because native Micro selection only covers six slots.

## Validation

- TypeScript check passed
- 79/79 automated tests passed
- Elgato validation passed for the build and exact packaged plugin
- exact Windows and macOS archives passed self-tests and read-only dry runs
- macOS launchers retained executable `0755` permissions
- all three extracted artifacts passed the private-state/protected-SVG audit
- live Windows/macOS inspection confirmed independent active-task detection without restarting Codex
