### PR TITLE
Fix cross-host task identity and prepare v0.7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.0.1 - 2026-07-22
+
+- Fixed one cross-host Codex task appearing twice when a new Windows or Mac thread transitioned from its temporary renderer ID to its stable rollout ID.
+- Remember resolved temporary thread aliases across later task selections and relay reconnects so mirrored tasks remain de-duplicated.
+- Preserve the available title and context usage from either host when the rollout owner temporarily publishes incomplete renderer metadata.
+- Reserve `Not assigned` for genuinely empty agent slots; assigned titleless threads now use `New chat` while their native title is pending.
+- Keep a neutral context ring visible until a new thread publishes its first token-count event.
+- Added bidirectional Windows-to-Mac and Mac-to-Windows regression coverage for task identity, title fallback, selection changes, and reconnects.
+
 ## 0.7.0 - 2026-07-21
 
 - Added a source-distributed native SwiftUI iPhone companion that merges authenticated Mac and Windows snapshots while leaving the Stream Deck plugin independent.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ npm run audit:release
 
 `npm run release:prepare` creates a versioned local release-candidate directory with the plugin package, Windows launcher ZIP, and SHA-256 checksums. The macOS ZIP must be created on macOS with `scripts/package-macos-release.sh` so executable bits survive; pass that ZIP to `scripts/prepare-release.ps1 -MacArchivePath ...`.
 
+For a four-component Stream Deck hotfix version, set
+`CODEX_DECK_RELEASE_VERSION=0.7.0.1` while running the macOS packager and pass
+`-ReleaseVersion 0.7.0.1` to `prepare-release.ps1`. The npm package keeps its
+SemVer-compatible prerelease form.
+
 Nothing is published automatically. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Acknowledgements

--- a/docs/IOS_INSTALL.md
+++ b/docs/IOS_INSTALL.md
@@ -34,7 +34,7 @@ For a released build, either download **Source code (zip)** from that GitHub
 release and extract it, or clone the matching tag in Terminal:
 
 ```zsh
-git clone --branch v0.7.0 --depth 1 https://github.com/dazer1234/codex-stream-deck.git
+git clone --branch v0.7.0.1 --depth 1 https://github.com/dazer1234/codex-stream-deck.git
 cd codex-stream-deck
 ```
 

--- a/docs/RELEASE_0.7.0.1.md
+++ b/docs/RELEASE_0.7.0.1.md
@@ -1,0 +1,32 @@
+# Codex Deck v0.7.0.1
+
+This hotfix hardens mirrored task identity between Windows and macOS Codex
+instances. It does not change the launcher, watcher, iPhone pairing, or native
+Codex Micro command surface introduced in v0.7.0.
+
+## Fixes
+
+- De-duplicates a new task while Codex transitions from its temporary renderer
+  ID to the stable rollout ID visible on the other host.
+- Remembers that mapping across later task selections and relay reconnects in
+  both Windows-to-Mac and Mac-to-Windows directions.
+- Uses the title and context usage available from either mirror when one host
+  temporarily publishes incomplete metadata.
+- Shows `New chat` for an assigned titleless thread and reserves `Not assigned`
+  for a genuinely empty agent slot.
+- Keeps a neutral context ring visible until the first token-count event arrives.
+
+## Downloads
+
+- Stream Deck: `com.simeo.codex-deck.streamDeckPlugin`
+- Windows launcher: `codex-deck-launcher-windows-v0.7.0.1.zip`
+- macOS launcher: `codex-deck-launcher-macos-v0.7.0.1.zip`
+- iPhone source: use the Source code archive or clone tag `v0.7.0.1`.
+- Checksums: `SHA256SUMS.txt`
+
+Existing v0.7.0 launcher and watcher installations remain compatible. Stream
+Deck users only need to install the updated plugin. Reload the Codex Deck
+Stream Deck plugin after updating; Codex itself does not need to restart.
+
+Codex Deck is an independent community project and is not made, supported, or
+endorsed by OpenAI or Elgato.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-stream-deck",
-  "version": "0.7.0",
+  "version": "0.7.0-hotfix.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-stream-deck",
-      "version": "0.7.0",
+      "version": "0.7.0-hotfix.1",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-stream-deck",
-  "version": "0.7.0",
+  "version": "0.7.0-hotfix.1",
   "private": false,
   "type": "module",
   "description": "Unofficial Codex Micro bridge for Stream Deck on Windows and macOS, with optional multi-host relay",

--- a/scripts/package-macos-release.sh
+++ b/scripts/package-macos-release.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT="${0:A:h:h}"
-VERSION="$(node -p "require('$ROOT/package.json').version")"
+PACKAGE_VERSION="$(node -p "require('$ROOT/package.json').version")"
+VERSION="${CODEX_DECK_RELEASE_VERSION:-$PACKAGE_VERSION}"
 OUTPUT="${1:-$ROOT/outputs/codex-deck-launcher-macos-v$VERSION.zip}"
 mkdir -p "${OUTPUT:h}"
 rm -f "$OUTPUT"

--- a/scripts/prepare-release.ps1
+++ b/scripts/prepare-release.ps1
@@ -48,7 +48,8 @@ try {
   }
   $artifacts = Get-ChildItem -LiteralPath $output -File | Sort-Object Name
   $checksums = @($artifacts | ForEach-Object { "{0}  {1}" -f (Get-Sha256Hex $_.FullName), $_.Name })
-  [IO.File]::WriteAllLines((Join-Path $output 'SHA256SUMS.txt'), $checksums, [Text.UTF8Encoding]::new($false))
+  $checksumText = ($checksums -join "`n") + "`n"
+  [IO.File]::WriteAllText((Join-Path $output 'SHA256SUMS.txt'), $checksumText, [Text.UTF8Encoding]::new($false))
   Write-Host "Release candidate prepared at: $output"
 } finally {
   Pop-Location

--- a/scripts/prepare-release.ps1
+++ b/scripts/prepare-release.ps1
@@ -1,4 +1,7 @@
-param([string]$MacArchivePath)
+param(
+  [string]$MacArchivePath,
+  [string]$ReleaseVersion
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -14,7 +17,10 @@ function Get-Sha256Hex([string]$Path) {
 
 $root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $package = Get-Content -LiteralPath (Join-Path $root 'package.json') -Raw | ConvertFrom-Json
-$version = [string]$package.version
+$version = if ([string]::IsNullOrWhiteSpace($ReleaseVersion)) { [string]$package.version } else { $ReleaseVersion.Trim() }
+if ($version -notmatch '^\d+\.\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?$') {
+  throw "Invalid release version: $version"
+}
 $output = Join-Path $root "outputs\release-v$version"
 
 Push-Location $root

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -415,7 +415,7 @@ export class DeckController {
     const unavailableTitle = health.state === "degraded" ? "Signals uncertain"
       : health.state === "offline" ? "Host offline"
         : health.state === "connecting" ? "Connecting" : "Not assigned";
-    const title = agent?.title ?? unavailableTitle;
+    const title = agent?.title ?? (agent?.threadKey && health.state === "ready" ? "New chat" : unavailableTitle);
     const status = agent ? visualStatusFromMicro(agent.status) : "empty";
     const theme = this.targetSnapshot()?.theme ?? this.localSnapshot?.snapshot.theme ?? "dark";
     const hostBadge = agent && this.relayClient ? (agent.host.platform === "darwin" ? "M" : "W") : undefined;

--- a/src/relay-protocol.ts
+++ b/src/relay-protocol.ts
@@ -415,6 +415,13 @@ function temporaryThreadAliases(inputs: HostSnapshot[]): Map<string, string> {
 
     for (const slot of input.snapshot.slots) {
       if (!slot.threadKey?.toLowerCase().includes(":client-new-thread:")) continue;
+      const activeIdentity = input.snapshot.activeThreadKey
+        ? threadIdentity(input.snapshot.activeThreadKey) : null;
+      if (slot.selected && activeIdentity && ownedSessions.has(activeIdentity) &&
+        !input.snapshot.activeThreadKey?.toLowerCase().includes(":client-new-thread:")) {
+        aliases.set(aliasKey(input.host, threadIdentity(slot.threadKey)), activeIdentity);
+        continue;
+      }
       const title = normalizedTitle(slot.title);
       if (!title) continue;
       const matches = new Set<string>();

--- a/src/relay-protocol.ts
+++ b/src/relay-protocol.ts
@@ -48,15 +48,18 @@ export type HostSnapshot = { host: CodexHost; snapshot: MicroSnapshot; observedA
 
 type ActivityRecord = { activityAt: number; signature: string; lastSeenAt: number };
 type SessionOwner = { input: HostSnapshot; session: HostSessionPresence };
+type TemporaryAliasRecord = { identity: string; lastSeenAt: number };
 const MIRROR_STATUS_FRESHNESS_MS = 5_000;
 const SESSION_COMPLETION_FALLBACK_MS = 5 * 60_000;
+const TEMPORARY_ALIAS_RETENTION_MS = 24 * 60 * 60_000;
 
 export class HostActivityIndex {
   private readonly activity = new Map<string, ActivityRecord>();
   private readonly acknowledgedCompletions = new Map<string, number>();
+  private readonly temporaryAliases = new Map<string, TemporaryAliasRecord>();
 
   merge(inputs: HostSnapshot[], now = Date.now(), authoritativeHostId?: string): RoutedAgentSlot[] {
-    const aliases = temporaryThreadAliases(inputs);
+    const aliases = temporaryThreadAliases(inputs, this.temporaryAliases, now);
     const routed: RoutedAgentSlot[] = [];
     for (const input of inputs) {
       for (const slot of input.snapshot.slots) {
@@ -334,10 +337,12 @@ function mergeMirrors(
   const contextCandidate = candidates.find((candidate) =>
     candidate.ownedByHost === true && candidate.contextUsedPercent != null)
     ?? candidates.find((candidate) => candidate.contextUsedPercent != null);
+  const titleCandidate = candidates.find((candidate) => normalizedTitle(candidate.title));
   return {
     ...owner,
     host: routedOwner,
     ownedByHost: sessionOwner ? true : owner.ownedByHost,
+    title: normalizedTitle(owner.title) ? owner.title : titleCandidate?.title ?? null,
     status,
     selected: statusCandidates.some((candidate) => candidate.selected),
     contextUsedPercent: sessionOwner?.session.contextUsedPercent ?? contextCandidate?.contextUsedPercent,
@@ -406,7 +411,11 @@ function threadIdentity(value: string): string {
   return value.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)?.[0]?.toLowerCase() ?? value;
 }
 
-function temporaryThreadAliases(inputs: HostSnapshot[]): Map<string, string> {
+function temporaryThreadAliases(
+  inputs: HostSnapshot[],
+  remembered: Map<string, TemporaryAliasRecord>,
+  now: number
+): Map<string, string> {
   const aliases = new Map<string, string>();
   for (const input of inputs) {
     const ownedSessions = new Set(
@@ -415,11 +424,18 @@ function temporaryThreadAliases(inputs: HostSnapshot[]): Map<string, string> {
 
     for (const slot of input.snapshot.slots) {
       if (!slot.threadKey?.toLowerCase().includes(":client-new-thread:")) continue;
+      const temporaryKey = aliasKey(input.host, threadIdentity(slot.threadKey));
+      const prior = remembered.get(temporaryKey);
+      if (prior && now - prior.lastSeenAt <= TEMPORARY_ALIAS_RETENTION_MS) {
+        aliases.set(temporaryKey, prior.identity);
+        prior.lastSeenAt = now;
+      }
       const activeIdentity = input.snapshot.activeThreadKey
         ? threadIdentity(input.snapshot.activeThreadKey) : null;
       if (slot.selected && activeIdentity && ownedSessions.has(activeIdentity) &&
         !input.snapshot.activeThreadKey?.toLowerCase().includes(":client-new-thread:")) {
-        aliases.set(aliasKey(input.host, threadIdentity(slot.threadKey)), activeIdentity);
+        aliases.set(temporaryKey, activeIdentity);
+        remembered.set(temporaryKey, { identity: activeIdentity, lastSeenAt: now });
         continue;
       }
       const title = normalizedTitle(slot.title);
@@ -434,9 +450,13 @@ function temporaryThreadAliases(inputs: HostSnapshot[]): Map<string, string> {
         }
       }
       if (matches.size !== 1) continue;
-      aliases.set(
-        aliasKey(input.host, threadIdentity(slot.threadKey)), [...matches][0]!);
+      const identity = [...matches][0]!;
+      aliases.set(temporaryKey, identity);
+      remembered.set(temporaryKey, { identity, lastSeenAt: now });
     }
+  }
+  for (const [key, record] of remembered) {
+    if (now - record.lastSeenAt > TEMPORARY_ALIAS_RETENTION_MS) remembered.delete(key);
   }
   return aliases;
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -78,7 +78,7 @@ export function renderAgentSvg(_slot: number, title: string, status: AgentVisual
     <rect x="12" y="12" width="120" height="120" rx="12" fill="url(#frost)" stroke="${surface.innerBorder}" stroke-width="1" opacity="${theme === "dark" ? ".86" : ".72"}"/>
     <path d="M18 21C46 12 99 12 126 23" fill="none" stroke="${surface.sheen}" stroke-width="6" stroke-linecap="round" opacity="${theme === "dark" ? "0" : ".68"}"/>
     ${renderHostHealthMark(hostHealth, theme)}
-    ${hostHealth === "ready" && showContextRing ? renderContextRing(contextUsedPercent, theme, surface) : ""}
+    ${hostHealth === "ready" && status !== "empty" && showContextRing ? renderContextRing(contextUsedPercent, theme, surface) : ""}
     ${hostBadge ? `<g data-agent-host="${escapeXml(hostBadge)}"><rect x="108" y="16" width="20" height="18" rx="7" fill="${surface.title}" fill-opacity=".11"/><text x="118" y="29" text-anchor="middle" font-family="Bahnschrift, Segoe UI, Arial, sans-serif" font-size="11" font-weight="700" fill="${surface.title}" fill-opacity=".82">${escapeXml(hostBadge)}</text></g>` : ""}
     <g font-family="Bahnschrift, Segoe UI Variable Display, Segoe UI, Arial, sans-serif">${titleMarkup}</g>
     ${statusMark}
@@ -331,7 +331,11 @@ function renderContextRing(
   theme: ThemeMode,
   surface: SurfacePalette
 ): string {
-  if (value == null || !Number.isFinite(value)) return "";
+  if (value == null || !Number.isFinite(value)) {
+    return `<g data-context-used="unknown" aria-label="Context usage pending">
+      <circle cx="25" cy="25" r="9" fill="${surface.keyMiddle}" fill-opacity=".58" stroke="${surface.title}" stroke-width="3" stroke-opacity=".18"/>
+    </g>`;
+  }
   const percent = Math.max(0, Math.min(100, value));
   const radius = 9;
   const circumference = 2 * Math.PI * radius;

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "Name": "Codex Deck",
-  "Version": "0.7.0.0",
+  "Version": "0.7.0.1",
   "Author": "Dazer",
   "Description": "Unofficial Codex Micro bridge for Stream Deck on Windows and macOS, with optional multi-host relay.",
   "UUID": "com.simeo.codex-deck",

--- a/test/micro-bridge.test.ts
+++ b/test/micro-bridge.test.ts
@@ -169,3 +169,9 @@ test("controller avoids overlapping polls and redundant image writes", async () 
   assert.match(source, /targetPlatform === "darwin"/);
   assert.doesNotMatch(source, /setInterval\(/);
 });
+
+test("assigned titleless threads use a new-chat label instead of Not assigned", async () => {
+  const source = await readFile(new URL("../src/controller.ts", import.meta.url), "utf8");
+  assert.match(source, /agent\?\.threadKey\s*&&\s*health\.state\s*===\s*"ready"\s*\?\s*"New chat"/);
+  assert.match(source, /:\s*"Not assigned"/);
+});

--- a/test/relay.test.ts
+++ b/test/relay.test.ts
@@ -347,7 +347,8 @@ test("temporary Windows new-thread keys merge with a titleless session-backed Ma
     selected: false, ownedByHost: false
   };
 
-  const merged = new HostActivityIndex().merge([
+  const index = new HostActivityIndex();
+  const merged = index.merge([
     { host: windows, snapshot: windowsSnapshot, observedAt: 2_000 },
     { host, snapshot: macSnapshot, observedAt: 2_000 }
   ], 2_000, windows.hostId);
@@ -360,6 +361,82 @@ test("temporary Windows new-thread keys merge with a titleless session-backed Ma
   assert.equal(matches[0]!.selected, true);
   assert.equal(matches[0]!.status, "working", "the live mirror status remains visible");
   assert.equal(matches[0]!.contextUsedPercent, 59);
+
+  windowsSnapshot.slots[0]!.selected = false;
+  windowsSnapshot.activeThreadKey = "10000000-0000-4000-8000-000000000000";
+  const afterSelectionMoves = index.merge([
+    { host: windows, snapshot: windowsSnapshot, observedAt: 3_000 },
+    { host, snapshot: macSnapshot, observedAt: 3_000 }
+  ], 3_000, windows.hostId).filter((slot) => slot.threadKey?.endsWith(rollout) || slot.threadKey === temporary);
+  assert.equal(afterSelectionMoves.length, 1, "the learned alias survives a later selection change");
+  assert.equal(afterSelectionMoves[0]!.title, title);
+});
+
+test("a titled mirror supplies the label when the rollout owner is titleless", () => {
+  const windows: CodexHost = {
+    hostId: "11111111-1111-4111-8111-111111111111", hostName: "Windows", platform: "win32"
+  };
+  const shared = "11000000-0000-4000-8000-000000000000";
+  const windowsSnapshot = structuredClone(snapshot);
+  const macSnapshot = structuredClone(snapshot);
+  windowsSnapshot.slots[0] = {
+    ...windowsSnapshot.slots[0]!, threadKey: shared, title: "Visible on Windows", ownedByHost: false
+  };
+  macSnapshot.slots[0] = {
+    ...macSnapshot.slots[0]!, threadKey: `local:${shared}`, title: null, ownedByHost: true
+  };
+  macSnapshot.hostSessions = [{ threadId: shared, activityAt: 2_000, status: "idle" }];
+
+  const merged = new HostActivityIndex().merge([
+    { host: windows, snapshot: windowsSnapshot, observedAt: 2_000 },
+    { host, snapshot: macSnapshot, observedAt: 2_000 }
+  ], 2_000, windows.hostId);
+  const matches = merged.filter((slot) => slot.threadKey?.endsWith(shared));
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.host.platform, "darwin");
+  assert.equal(matches[0]!.title, "Visible on Windows");
+});
+
+test("a learned Mac new-thread alias survives a Windows relay reconnect", () => {
+  const windows: CodexHost = {
+    hostId: "11111111-1111-4111-8111-111111111111", hostName: "Windows", platform: "win32"
+  };
+  const temporary = "local:client-new-thread:12000000-0000-4000-8000-000000000000";
+  const rollout = "13000000-0000-4000-8000-000000000000";
+  const title = "New Mac task";
+  const windowsSnapshot = structuredClone(snapshot);
+  const macSnapshot = structuredClone(snapshot);
+  windowsSnapshot.agentSource = "priority";
+  macSnapshot.agentSource = "priority";
+  windowsSnapshot.slots[0] = {
+    ...windowsSnapshot.slots[0]!, threadKey: rollout, title: null, status: "working",
+    selected: false, ownedByHost: false
+  };
+  macSnapshot.activeThreadKey = rollout;
+  macSnapshot.slots[0] = {
+    ...macSnapshot.slots[0]!, threadKey: temporary, title, status: "working",
+    selected: true, ownedByHost: false
+  };
+  macSnapshot.hostSessions = [
+    { threadId: rollout, activityAt: 2_000, status: "working", contextUsedPercent: 12 }
+  ];
+  const index = new HostActivityIndex();
+  const inputs = () => [
+    { host: windows, snapshot: windowsSnapshot, observedAt: 2_000 },
+    { host, snapshot: macSnapshot, observedAt: 2_000 }
+  ];
+
+  assert.equal(index.merge(inputs(), 2_000, windows.hostId)
+    .filter((slot) => slot.threadKey?.endsWith(rollout) || slot.threadKey === temporary).length, 1);
+  index.merge([{ host: windows, snapshot: windowsSnapshot, observedAt: 2_500 }], 2_500, windows.hostId);
+  macSnapshot.slots[0]!.selected = false;
+  macSnapshot.activeThreadKey = "14000000-0000-4000-8000-000000000000";
+  const reconnected = index.merge(inputs().map((input) => ({ ...input, observedAt: 3_000 })), 3_000, windows.hostId)
+    .filter((slot) => slot.threadKey?.endsWith(rollout) || slot.threadKey === temporary);
+  assert.equal(reconnected.length, 1);
+  assert.equal(reconnected[0]!.host.platform, "darwin");
+  assert.equal(reconnected[0]!.title, title);
+  assert.equal(reconnected[0]!.contextUsedPercent, 12);
 });
 
 test("delayed mirror status does not reorder an owned active task", () => {

--- a/test/relay.test.ts
+++ b/test/relay.test.ts
@@ -323,7 +323,7 @@ test("host session catalogs return a Mac-only cloud mirror to its Windows owner"
   assert.equal(match?.status, "working");
 });
 
-test("temporary Windows new-thread keys merge with the session-backed Mac mirror", () => {
+test("temporary Windows new-thread keys merge with a titleless session-backed Mac mirror", () => {
   const windows: CodexHost = {
     hostId: "11111111-1111-4111-8111-111111111111", hostName: "Windows", platform: "win32"
   };
@@ -334,16 +334,16 @@ test("temporary Windows new-thread keys merge with the session-backed Mac mirror
   const macSnapshot = structuredClone(snapshot);
   windowsSnapshot.agentSource = "priority";
   macSnapshot.agentSource = "priority";
-  windowsSnapshot.activeThreadKey = temporary;
+  windowsSnapshot.activeThreadKey = rollout;
   windowsSnapshot.slots[0] = {
     ...windowsSnapshot.slots[0]!, threadKey: temporary, title, status: "idle",
     selected: true, ownedByHost: false
   };
   windowsSnapshot.hostSessions = [
-    { threadId: rollout, activityAt: 2_000, status: "complete", completionRevision: 10 }
+    { threadId: rollout, activityAt: 2_000, status: "working", contextUsedPercent: 59 }
   ];
   macSnapshot.slots[0] = {
-    ...macSnapshot.slots[0]!, threadKey: `local:${rollout}`, title, status: "working",
+    ...macSnapshot.slots[0]!, threadKey: `local:${rollout}`, title: null, status: "working",
     selected: false, ownedByHost: false
   };
 
@@ -359,6 +359,7 @@ test("temporary Windows new-thread keys merge with the session-backed Mac mirror
   assert.equal(matches[0]!.threadKey, temporary, "commands keep the live Windows slot key");
   assert.equal(matches[0]!.selected, true);
   assert.equal(matches[0]!.status, "working", "the live mirror status remains visible");
+  assert.equal(matches[0]!.contextUsedPercent, 59);
 });
 
 test("delayed mirror status does not reorder an owned active task", () => {

--- a/test/release-docs.test.ts
+++ b/test/release-docs.test.ts
@@ -16,7 +16,7 @@ test("iPhone source-install docs state the current Mac and distribution boundary
     assert.match(prose, /control only\s+(?:a\s+)?Windows/i);
     assert.match(prose, /App Store/);
   }
-  assert.match(install, /git clone --branch v0\.7\.0 --depth 1/);
+  assert.match(install, /git clone --branch v0\.7\.0\.1 --depth 1/);
 });
 
 test("release docs preserve inspiration credit and independent implementation wording", async () => {

--- a/test/release-docs.test.ts
+++ b/test/release-docs.test.ts
@@ -39,3 +39,10 @@ test("local Wi-Fi guide proves Nearby works with Tailscale off and keeps CDP pri
   assert.match(guide, /Chrome DevTools/);
   assert.doesNotMatch(guide, /0\.0\.0\.0/);
 });
+
+test("release checksums use portable LF line endings on Windows", async () => {
+  const source = await text("scripts/prepare-release.ps1");
+  assert.match(source, /\$checksums -join "`n"/);
+  assert.match(source, /WriteAllText/);
+  assert.doesNotMatch(source, /WriteAllLines/);
+});

--- a/test/render-theme.test.ts
+++ b/test/render-theme.test.ts
@@ -29,8 +29,11 @@ test("agent context ring is bounded and can be hidden globally", () => {
   const hidden = renderAgentSvg(0, "Context test", "thinking", false, 0, "dark", "M", "ready", 84, false);
   assert.doesNotMatch(hidden, /data-context-used=/);
 
-  const unavailable = renderAgentSvg(0, "No context", "idle", false, 0, "dark", "M", "ready", undefined, true);
-  assert.doesNotMatch(unavailable, /data-context-used=/);
+  const pending = renderAgentSvg(0, "New task", "idle", false, 0, "dark", "M", "ready", undefined, true);
+  assert.match(pending, /data-context-used="unknown"/);
+
+  const empty = renderAgentSvg(0, "Not assigned", "empty", false, 0, "dark", "M", "ready", undefined, true);
+  assert.doesNotMatch(empty, /data-context-used=/);
 });
 
 test("user-local monochrome SVGs normalize to an off-white dark glyph", () => {


### PR DESCRIPTION
## What changed

- de-duplicate temporary and stable Codex task identities across Windows and macOS
- retain learned aliases across selection changes and relay reconnects
- preserve titles and context rings when one host publishes incomplete metadata
- reserve Not assigned for empty slots
- prepare Stream Deck hotfix version 0.7.0.1 and portable release artifacts

## Root cause

A newly created task can temporarily have different renderer and rollout IDs on the two Codex hosts. Titleless mirror metadata prevented the existing title-based fallback from identifying both entries as the same task.

## Validation

- TypeScript check
- 130/130 tests on Windows
- 129/130 tests on macOS with the Windows-only watcher test skipped
- Stream Deck validate and pack
- release privacy audit
- macOS executable-mode archive check
- portable SHA256SUMS verification on macOS
- exact packaged-to-installed plugin hash parity on the physical Windows Stream Deck setup
- live merged Mac and Windows snapshots with two working tasks, no duplicates, and no assigned titleless slots

Codex was not restarted.