### PR TITLE
Normalize local thread IDs during agent activation

### DIFF
--- a/src/codex-micro-renderer-bridge.ts
+++ b/src/codex-micro-renderer-bridge.ts
@@ -42,6 +42,12 @@ export type AgentDispatchPlan =
   | { kind: "native"; slot: number; threadKey: string }
   | { kind: "direct"; threadKey: string };
 
+export function localThreadKeyVariants(threadKey: string): string[] {
+  return threadKey.startsWith("local:")
+    ? [threadKey, threadKey.slice("local:".length)]
+    : [threadKey, `local:${threadKey}`];
+}
+
 export function resolveAgentDispatch(
   snapshot: MicroSnapshot,
   requestedSlot: number,
@@ -352,8 +358,10 @@ export class CodexMicroRendererBridge {
   }
 
   private async ensureThreadActivated(threadKey: string): Promise<void> {
+    const threadKeyVariants = localThreadKeyVariants(threadKey);
     const result = await this.evaluate<"active" | "opened" | "missing" | "failed">(`(async () => {
       const threadKey = ${JSON.stringify(threadKey)};
+      const threadKeyVariants = ${JSON.stringify(threadKeyVariants)};
       const activeThreadKey = () => document.querySelector('[data-above-composer-conversation-id]')
         ?.getAttribute('data-above-composer-conversation-id')
         ?? document.querySelector('[data-app-action-sidebar-thread-id][data-app-action-sidebar-thread-active="true"]')
@@ -364,14 +372,14 @@ export class CodexMicroRendererBridge {
       const waitForActive = async (duration) => {
         const deadline = Date.now() + duration;
         while (Date.now() < deadline) {
-          if (activeThreadKey() === threadKey) return true;
+          if (threadKeyVariants.includes(activeThreadKey())) return true;
           await new Promise((resolve) => setTimeout(resolve, 25));
         }
-        return activeThreadKey() === threadKey;
+        return threadKeyVariants.includes(activeThreadKey());
       };
       if (await waitForActive(250)) return 'active';
       const item = [...document.querySelectorAll('[data-app-action-sidebar-thread-id]')]
-        .find((element) => element.getAttribute('data-app-action-sidebar-thread-id') === threadKey);
+        .find((element) => threadKeyVariants.includes(element.getAttribute('data-app-action-sidebar-thread-id')));
       if (!item) return 'missing';
       const selector = 'button, a, [role="button"], [role="link"]';
       const clickable = item.matches(selector) ? item : item.querySelector(selector) ?? item.closest(selector) ?? item;

--- a/test/micro-bridge.test.ts
+++ b/test/micro-bridge.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
-  REASONING_ENCODER_KEYS, resolveAgentDispatch, retainEvaluationPromise, selectCodexMainTarget
+  localThreadKeyVariants, REASONING_ENCODER_KEYS, resolveAgentDispatch, retainEvaluationPromise, selectCodexMainTarget
 } from "../src/codex-micro-renderer-bridge.js";
 import { ADDITIONAL_KEYCAPS, OFFICIAL_KEYCAP_IDS } from "../src/keycaps.js";
 import { visualStatusFromMicro } from "../src/status.js";
@@ -75,6 +75,12 @@ test("renderer evaluations retain their awaited promise until CDP has collected 
   assert.match(expression, /setTimeout\(\(\) => store\.delete/);
   const namespaced = retainEvaluationPromise("Promise.resolve(true)", "bridge-a-1");
   assert.match(namespaced, /codex-deck-bridge-a-1/);
+});
+
+test("renderer activation accepts local-prefixed and bare forms of the same thread key", () => {
+  const threadId = "019fc4e4-4ecc-7f20-b7f5-855c11da7b37";
+  assert.deepEqual(localThreadKeyVariants(`local:${threadId}`), [`local:${threadId}`, threadId]);
+  assert.deepEqual(localThreadKeyVariants(threadId), [threadId, `local:${threadId}`]);
 });
 
 test("agent routing follows the stable thread identity when a cross-host slot is stale", () => {


### PR DESCRIPTION
## What changed

- Treat bare task IDs and their `local:`-prefixed forms as equivalent when verifying agent-key navigation.
- Use the same variants when locating a sidebar task.
- Add a regression test for both identifier directions.

## Why

Codex for macOS `26.727.51351` reports the active composer conversation as a bare UUID while sidebar task elements and Codex Micro slots still use `local:<uuid>`. Codex Deck successfully changes tasks, but its literal post-navigation comparison times out and calls `showAlert()`, producing a yellow warning triangle on the Stream Deck.

This keeps exact matching scoped to the optional `local:` prefix and avoids changing cross-host routing identities.

## Validation

- `npm run check`
- `npm test` — 134 passed, 1 expected Windows-only skip
- `npm run validate`
- Reproduced against Codex for macOS `26.727.51351` and Stream Deck `7.4.2.22730`; the equivalent comparison removes the false activation failure.