### PR TITLE
fix: short-circuit MIC keycap to native HID path (fixes #11)

### DIFF
--- a/src/codex-micro-renderer-bridge.ts
+++ b/src/codex-micro-renderer-bridge.ts
@@ -408,6 +408,17 @@ export class CodexMicroRendererBridge {
 
   async runKeycap(keycapId: OfficialKeycapId): Promise<void> {
     if (!OFFICIAL_KEYCAP_IDS.includes(keycapId)) throw new Error(`Unknown Codex Micro keycap: ${keycapId}`);
+    
+    // Short-circuit MIC keycap to use native HID path (ACT10 for push-to-talk toggle)
+    // The MIC keycap action type is now 'named' which isn't handled by the JS evaluation path,
+    // and the VS Code API module no longer exists in the build.
+    // Native HID path (ACT10) still works for dictation push-to-talk.
+    if (keycapId === "MIC") {
+      await this.ensureConnected();
+      await this.dispatch("codex-micro-hid-event", { event: { key: "ACT10", act: 1, slot: null, threadKey: null } }, "codex-micro-hid-event");
+      return;
+    }
+    
     await this.ensureConnected();
     const expression = `(async () => {
       const urls = [...new Set([


### PR DESCRIPTION
## Summary

The MIC keycap action type changed to 'named' which isn't handled by the JS evaluation path in runKeycap(). The VS Code API module no longer exists in the build, causing 'Codex VS Code event module is unavailable for this keycap' error.

This fix short-circuits the MIC keycap to use the native HID path (codex-micro-hid-event with key ACT10 for push-to-talk toggle), which still works for dictation.

## Changes

- Modified \unKeycap()\ in \src/codex-micro-renderer-bridge.ts\ to short-circuit the MIC keycap
- Uses native HID path (codex-micro-hid-event with key ACT10) for push-to-talk toggle
- This bypasses the JS evaluation path that fails on 'named' action type

## Testing

- TypeScript compilation passes
- Build passes

## Bounty Claim

/claim #11

Fixes #11